### PR TITLE
Added support for lacking content-disposition and lacking filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ Now, having this two key values then you can implement it:
 	var boundary = "----WebKitFormBoundaryDtbT5UpPj83kllfw";
 	var parts = multipart.Parse(body,boundary);
 	
-	for(var i=0;i<parts.length;i++){
+	for(let part of parts){
 		var part = parts[i];
 		// will be:
-		// { filename: 'A.txt', type: 'text/plain', 
+		// { name: 'userfile', filename: 'A.txt', type: 'text/plain', 
 		//		data: <Buffer 41 41 41 41 42 42 42 42> }
+		// In the event of multiple files with the same "name" attribute, a part will be an array of files. Such as during a multi file upload.
+		// If no filename is supplied it will be ignored, if no name is supplied it will be null
 	}
 ```
 


### PR DESCRIPTION
This PR rewrites the process function.
In the PR I've added support for lacking Content-Disposition as per a multipart/related request where it isn't mandatory.

Added support for lacking filename which also isn't mandatory.
Feel free to use any of the code in the PR.

It should be pretty easy to expand on my code to add support for different headers.
The code was tested with Amazon AWS V1 Speech Recognition.

An example payload from Amazon AWS V1:
http://haste.thomas-edwards.me/usitucezad.txt

Note the lack of Content-Disposition.

One last addition,
A requests entire headers object and now be supplied to getBoundary and it'll try and extract content-type. Although will work fine as it did originally.