### PR TITLE
formData fields support.

### DIFF
--- a/multipart.js
+++ b/multipart.js
@@ -33,7 +33,15 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 			{ value: b, writable: true, enumerable: true, configurable: true })
 			return o;
 		}
-		var header = part.header.split(';');		
+		var header = part.header.split(';');
+		
+		if(part.fieldInfo != null && part.fieldInfo != ""){
+			var field = obj(header[1]);
+			Object.defineProperty( field , 'data' ,
+				{ value: part.fieldInfo, writable: true, enumerable: true, configurable: true })
+			return field;
+		}
+		
 		var file = obj(header[2]);
 		var contentType = part.info.split(':')[1].trim();		
 		Object.defineProperty( file , 'type' , 
@@ -47,6 +55,7 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 	var header = '';
 	var info = ''; var state=0; var buffer=[];
 	var allParts = [];
+	var fieldInfo = '';  // this will hold the field info when part is not a file.
 
 	for(i=0;i<multipartBodyBuffer.length;i++){
 		var oneByte = multipartBodyBuffer[i];
@@ -74,6 +83,7 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 			lastline='';
 		}else
 		if((3 == state) && newLineDetected){
+			fieldInfo = lastline; // fieldInfo is exposed in lastline on this step.
 			state=4;
 			buffer=[];
 			lastline='';
@@ -83,7 +93,7 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 			if(((("--"+boundary) == lastline))){
 				var j = buffer.length - lastline.length;
 				var part = buffer.slice(0,j-1);
-				var p = { header : header , info : info , part : part  };
+				var p = { header : header , info : info , part : part, fieldInfo : fieldInfo  };  // adding fieldInfo to the part to process
 				allParts.push(process(p));
 				buffer = []; lastline=''; state=5; header=''; info='';
 			}else{


### PR DESCRIPTION
This will enable the Parser to parse field parts included in formData. Ej. (parsed data):
parts: 
{ name: 'name', data: 'test product' }
{ name: 'code', data: 'product code' }
{ name: 'category', data: 'product category' }
{ filename: 'productImage.jpg',
  type: 'image/jpeg',
  data: <Buffer ef bf bd ef bf bd ef bf bd ef bf bd 00 10 4a 46 49 46 00 01 01 00 00 01 00 01 00 00 ef bf bd ef bf bd 00 43 00 03 02 02 02 02 02 03 02 02 02 03 03 03 ... > }