### PR TITLE
Enable support of having only Content-id header field

### DIFF
--- a/multipart.js
+++ b/multipart.js
@@ -34,7 +34,7 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 			return o;
 		}
 		var header = part.header.split(';');		
-		var file = obj(header[2]);
+		var file = (header.length >= 2) ? obj(header[2]): {};
 		var contentType = part.info.split(':')[1].trim();		
 		Object.defineProperty( file , 'type' , 
 			{ value: contentType, writable: true, enumerable: true, configurable: true })


### PR DESCRIPTION
Current implementation assumes that the there are more tuples in the header, but in my multipart/related response there is only one which is Content-id, so removing the expectation of having more tuples.