### PR TITLE
Parse the 'name' field and return it

### DIFF
--- a/multipart.js
+++ b/multipart.js
@@ -34,13 +34,17 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 			return o;
 		}
 		var header = part.header.split(';');		
-		var name = obj(header[1]);
 		var file = obj(header[2]);
-		Object.defineProperty( file , 'name' , 
-			{ value: name, writable: true, enumerable: true, configurable: true })
 		var contentType = part.info.split(':')[1].trim();		
 		Object.defineProperty( file , 'type' , 
 			{ value: contentType, writable: true, enumerable: true, configurable: true })
+		
+		try {
+			var name = obj(header[1])['name'];
+			Object.defineProperty( file , 'name' , 
+				{ value: name, writable: true, enumerable: true, configurable: true })
+		} catch(err) {}
+		
 		Object.defineProperty( file , 'data' , 
 			{ value: new Buffer(part.part), writable: true, enumerable: true, configurable: true })
 		return file;


### PR DESCRIPTION
Hi,
I did a small patch to parse and return the `name` field, and return it.
Was useful for having multiple uploaded files which are differentiated by unique `name` attributes in the html `input` tag.