### PR TITLE
Handle missing filename header

### DIFF
--- a/multipart.js
+++ b/multipart.js
@@ -34,7 +34,7 @@ exports.Parse = function(multipartBodyBuffer,boundary){
 			return o;
 		}
 		var header = part.header.split(';');		
-		var file = obj(header[2]);
+		var file = header.length > 2 ? obj(header[2]) : {}
 		var contentType = part.info.split(':')[1].trim();		
 		Object.defineProperty( file , 'type' , 
 			{ value: contentType, writable: true, enumerable: true, configurable: true })


### PR DESCRIPTION
Quick fix to avoid crashing when filename is not specified.