### PR TITLE
remove zero padding of version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-multipart",
-  "version": "1.0.0004",
+  "version": "1.0.4",
   "description": "A javascript/nodejs multipart/form-data parser which operates on raw data.",
   "main": "multipart.js",
   "author": "Cristian Salazar (christiansalazarh@gmail.com)",


### PR DESCRIPTION
This breaks semver on arc.codes, since simple string match fails.